### PR TITLE
fix: specify base to parseInt()

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -8,7 +8,7 @@ export async function run(): Promise<void> {
   core.info('Starting...')
 
   const baseBranch = core.getInput('base-branch') || 'main'
-  const treshold = parseInt(core.getInput('treshold')) || 300 // ms
+  const treshold = parseInt(core.getInput('treshold'), 10) || 300 // ms
   const customCommand = core.getInput('custom-command') || undefined
   const extended = core.getInput('extended') === 'true'
 
@@ -163,12 +163,12 @@ function parseDiagnostics(input: string): Diagnostics {
         }
       } else if (value.endsWith('K')) {
         diagnostics[key] = {
-          value: parseInt(value.replace('K', '')),
+          value: parseInt(value.replace('K', ''), 10),
           unit: 'K'
         }
       } else {
         diagnostics[key] = {
-          value: parseInt(value),
+          value: parseInt(value, 10),
           unit: ''
         }
       }


### PR DESCRIPTION
The parseInt() function takes a 2nd parameter, the radix (base) that always should be specified if you want to convert a string to a number (in base 10), see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#description