### PR TITLE
fix: use package manager to resolve binary

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -23,13 +23,11 @@ export async function run(): Promise<void> {
     let command = customCommand
     if (!command) {
       core.debug(`Getting location of tsc binary`)
-      const bin =
-        packageManager !== 'npm'
-          ? (await exec.getExecOutput(`${packageManager} bin`)).stdout.trim()
-          : (await exec.getExecOutput(`npm prefix`)).stdout.trim() +
-            '/node_modules/.bin'
-      const tsc = `${bin}/tsc`
-      core.debug(`tsc: ${tsc}, bin: ${bin}`)
+      const prefix = (
+        await exec.getExecOutput(`${packageManager} prefix`)
+      ).stdout.trim()
+      const tsc = `${prefix}/node_modules/.bin/tsc`
+      core.debug(`tsc: ${tsc}, bin: ${prefix}`)
 
       command = `${tsc} ${
         extended ? '--extendedDiagnostics' : '--diagnostics'

--- a/src/run.ts
+++ b/src/run.ts
@@ -17,15 +17,24 @@ export async function run(): Promise<void> {
     core.getInput('github-token') || undefined
 
   try {
-    const bin = (await exec.getExecOutput('yarn bin')).stdout.trim()
-    const tsc = `${bin}/tsc`
-    core.debug(`tsc: ${tsc}, bin: ${bin}`)
+    const packageManager = await detect()
+    core.debug(`package manager: ${packageManager}`)
 
-    const command = customCommand
-      ? customCommand
-      : `${tsc} ${
-          extended ? '--extendedDiagnostics' : '--diagnostics'
-        } --incremental false`
+    let command = customCommand
+    if (!command) {
+      core.debug(`Getting location of tsc binary`)
+      const bin =
+        packageManager !== 'npm'
+          ? (await exec.getExecOutput(`${packageManager} bin`)).stdout.trim()
+          : (await exec.getExecOutput(`npm prefix`)).stdout.trim() +
+            '/node_modules/.bin'
+      const tsc = `${bin}/tsc`
+      core.debug(`tsc: ${tsc}, bin: ${bin}`)
+
+      command = `${tsc} ${
+        extended ? '--extendedDiagnostics' : '--diagnostics'
+      } --incremental false`
+    }
 
     const newResult = await exec.getExecOutput(command)
     if (!newResult.stdout.includes('Check time') && customCommand) {
@@ -37,8 +46,6 @@ export async function run(): Promise<void> {
     await git.fetch(githubToken, baseBranch)
     await git.cmd([], 'checkout', baseBranch)
 
-    const packageManager = await detect()
-    core.debug(`package manager: ${packageManager}`)
     core.debug(`installing dependencies with ${packageManager}`)
     if (packageManager === 'yarn') {
       await exec.exec('yarn')


### PR DESCRIPTION
context: https://github.com/danielroe/magic-regexp/actions/runs/5766431293/job/15634362015?pr=350

This PR does two things:
1. it does not bother resolving `tsc` location if a custom command has been provided
2. it uses the detected package manager to resolve binary directory rather than `yarn` (which will fail in a corepack-enabled project). I think we can safely use `prefix` command and resolve it to `node_modules/.bin` as I think this is the behaviour for npm/yarn/pnpm.